### PR TITLE
Added support of Curve group element based evalutation of lagrange coefficients.

### DIFF
--- a/include/nil/crypto3/math/domains/basic_radix2_domain.hpp
+++ b/include/nil/crypto3/math/domains/basic_radix2_domain.hpp
@@ -100,6 +100,16 @@ namespace nil {
                     return detail::basic_radix2_evaluate_all_lagrange_polynomials<FieldType>(this->m, t);
                 }
 
+                std::vector<value_type> evaluate_all_lagrange_polynomials(const typename std::vector<value_type>::const_iterator &t_powers_begin,
+                                                                          const typename std::vector<value_type>::const_iterator &t_powers_end) {
+                    if (std::distance(t_powers_begin, t_powers_end) < this->m) {
+                        throw std::invalid_argument("basic_radix2: expected std::distance(t_powers_begin, t_powers_end) >= this->m");
+                    }
+                    std::vector<value_type> tmp(t_powers_begin, t_powers_begin + this->m);
+                    this->inverse_fft(tmp);
+                    return tmp;
+                }
+
                 field_value_type get_domain_element(const std::size_t idx) {
                     return omega.pow(idx);
                 }

--- a/include/nil/crypto3/math/domains/evaluation_domain.hpp
+++ b/include/nil/crypto3/math/domains/evaluation_domain.hpp
@@ -95,6 +95,18 @@ namespace nil {
                 virtual std::vector<field_value_type> evaluate_all_lagrange_polynomials(const field_value_type &t) = 0;
 
                 /**
+                 * Evaluate all Lagrange polynomials.
+                 *
+                 * The inputs are:
+                 * - an integer m
+                 * - a vector (t**0,...,t**(m-1)) t_powers for some element t
+                 * The output is a vector (b_{0},...,b_{m-1})
+                 * where b_{i} is the evaluation of L_{i,S}(z) at z = t.
+                 */
+                virtual std::vector<value_type> evaluate_all_lagrange_polynomials(const typename std::vector<value_type>::const_iterator &t_powers_begin,
+                                                                                  const typename std::vector<value_type>::const_iterator &t_powers_end) = 0;
+
+                /**
                  * Evaluate the vanishing polynomial of S at the field element t.
                  */
                 virtual field_value_type compute_vanishing_polynomial(const field_value_type &t) = 0;

--- a/test/evaluation_domain.cpp
+++ b/test/evaluation_domain.cpp
@@ -61,20 +61,6 @@
 using namespace nil::crypto3::algebra;
 using namespace nil::crypto3::math;
 
-template<typename EvaluationDomainType>
-std::size_t find_m() {
-    for(std::size_t m = 4; m < 100; ++m) {
-        try{
-            EvaluationDomainType d(m);
-            return m;
-        } catch(std::invalid_argument &e) {
-            // continute;
-        }
-    }
-    BOOST_FAIL(std::string("Could not find m below 100 for ") + typeid(EvaluationDomainType).name());
-    return 4;
-}
-
 /**
  * Note: Templatized type referenced with FieldType (instead of canonical FieldType)
  * https://github.com/google/googletest/blob/master/googletest/docs/AdvancedGuide.md#typed-tests
@@ -215,7 +201,7 @@ void test_fft_curve_elements() {
     typedef typename GroupType::value_type value_type;
     typedef typename FieldType::value_type field_value_type;
 
-    std::size_t m = find_m<EvaluationDomainType>();
+    std::size_t m = 4;
     
     // Make sure the results are reproducible.
     std::srand(0);
@@ -251,7 +237,7 @@ void test_inverse_fft_curve_elements() {
     typedef typename GroupType::value_type value_type;
     typedef typename FieldType::value_type field_value_type;
 
-    std::size_t m = find_m<EvaluationDomainType>();
+    std::size_t m = 4;
 
     // Make sure the results are reproducible.
     std::srand(0);
@@ -277,6 +263,67 @@ void test_inverse_fft_curve_elements() {
     
     for(std::size_t i = 0; i < f.size(); ++i) {
         BOOST_CHECK(f[i] * value_type::one() == g[i]);
+    }
+
+    std::cout << "type name " << typeid(EvaluationDomainType).name() << std::endl;
+}
+
+template<typename FieldType, typename EvaluationDomainType>
+void test_lagrange_coefficients_from_powers(std::size_t m) {
+    typedef typename FieldType::value_type field_value_type;
+
+    // Make sure the results are reproducible.
+    std::srand(0);
+    field_value_type t = std::rand();
+    std::vector<field_value_type> t_powers(m);
+    t_powers[0] = field_value_type::one();
+    for(std::size_t i = 1; i < m; ++i) {
+        t_powers[i] = t_powers[i-1] * t;
+    }
+ 
+    std::shared_ptr<evaluation_domain<FieldType>> domain;
+
+    domain.reset(new EvaluationDomainType(m));
+
+    std::vector<field_value_type> u = domain->evaluate_all_lagrange_polynomials(t);
+    std::vector<field_value_type> u_from_powers = domain->evaluate_all_lagrange_polynomials(t_powers.cbegin(), t_powers.cend());
+
+    BOOST_CHECK_EQUAL(u.size(), u_from_powers.size());
+
+    for(std::size_t i = 0; i < u.size(); ++i) {
+        BOOST_CHECK(u[i] == u_from_powers[i]);
+    }
+
+    std::cout << "type name " << typeid(EvaluationDomainType).name() << std::endl;
+}
+
+template<typename FieldType, typename GroupType, typename EvaluationDomainType, typename GroupEvaluationDomainType>
+void test_lagrange_coefficients_curve_elements(std::size_t m) {
+    typedef typename FieldType::value_type field_value_type;
+    typedef typename GroupType::value_type value_type;
+
+    // Make sure the results are reproducible.
+    std::srand(0);
+    field_value_type t = std::rand();
+    std::vector<value_type> t_powers(m);
+    t_powers[0] = value_type::one();
+    for(std::size_t i = 1; i < m; ++i) {
+        t_powers[i] = t_powers[i-1] * t;
+    }
+ 
+    std::shared_ptr<evaluation_domain<FieldType>> domain;
+    domain.reset(new EvaluationDomainType(m));
+    
+    std::shared_ptr<evaluation_domain<FieldType, value_type>> curve_element_domain;
+    curve_element_domain.reset(new GroupEvaluationDomainType(m));
+
+    std::vector<field_value_type> u = domain->evaluate_all_lagrange_polynomials(t);
+    std::vector<value_type> u_curve_element = curve_element_domain->evaluate_all_lagrange_polynomials(t_powers.cbegin(), t_powers.cend());
+
+    BOOST_CHECK_EQUAL(u.size(), u_curve_element.size());
+
+    for(std::size_t i = 0; i < u.size(); ++i) {
+        BOOST_CHECK(u[i] * value_type::one() == u_curve_element[i]);
     }
 
     std::cout << "type name " << typeid(EvaluationDomainType).name() << std::endl;
@@ -331,11 +378,10 @@ BOOST_AUTO_TEST_CASE(curve_elements_fft) {
                             group_type,
                             geometric_sequence_domain<field_type>,
                             geometric_sequence_domain<field_type, group_value_type>>();
-    // not applicable  for this field
-    // test_fft_curve_elements<field_type,
-    //                         group_type,
-    //                         arithmetic_sequence_domain<field_type>,
-    //                         arithmetic_sequence_domain<field_type, group_value_type>>();
+    test_fft_curve_elements<field_type,
+                            group_type,
+                            arithmetic_sequence_domain<field_type>,
+                            arithmetic_sequence_domain<field_type, group_value_type>>();
 }
 
 BOOST_AUTO_TEST_CASE(curve_elements_inverse_fft) {
@@ -360,11 +406,54 @@ BOOST_AUTO_TEST_CASE(curve_elements_inverse_fft) {
                             group_type,
                             geometric_sequence_domain<field_type>,
                             geometric_sequence_domain<field_type, group_value_type>>();
-    // not applicable for this field
-    // test_inverse_fft_curve_elements<field_type,
+    test_inverse_fft_curve_elements<field_type,
+                            group_type,
+                            arithmetic_sequence_domain<field_type>,
+                            arithmetic_sequence_domain<field_type, group_value_type>>();
+}
+
+BOOST_AUTO_TEST_CASE(lagrange_coefficients_from_powers) {
+    typedef curves::bls12<381>::scalar_field_type field_type;
+    
+    test_lagrange_coefficients_from_powers<field_type,
+                            basic_radix2_domain<field_type>>(4);
+    // not applicable for any m < 100 for this field, testing with base field instead
+    test_lagrange_coefficients_from_powers<fields::bls12<381>,
+                            extended_radix2_domain<fields::bls12<381>>>(4);
+    test_lagrange_coefficients_from_powers<field_type,
+                            step_radix2_domain<field_type>>(4);
+    test_lagrange_coefficients_from_powers<field_type,
+                            geometric_sequence_domain<field_type>>(4);
+    test_lagrange_coefficients_from_powers<field_type,
+                            arithmetic_sequence_domain<field_type>>(4);
+}
+
+BOOST_AUTO_TEST_CASE(curve_elements_lagrange_coefficients) {
+    typedef curves::bls12<381>::scalar_field_type field_type;
+    typedef curves::bls12<381>::g1_type<> group_type;
+    using group_value_type = group_type::value_type;
+    
+    test_lagrange_coefficients_curve_elements<field_type,
+                            group_type,
+                            basic_radix2_domain<field_type>,
+                            basic_radix2_domain<field_type, group_value_type>>(4);
+    // not applicable for any m < 100 for this field 
+    // test_lagrange_coefficients_curve_elements<field_type,
     //                         group_type,
-    //                         arithmetic_sequence_domain<field_type>,
-    //                         arithmetic_sequence_domain<field_type, group_value_type>>();
+    //                         extended_radix2_domain<field_type>,
+    //                         extended_radix2_domain<field_type, group_value_type>>(4);
+    test_lagrange_coefficients_curve_elements<field_type,
+                            group_type,
+                            step_radix2_domain<field_type>,
+                            step_radix2_domain<field_type, group_value_type>>(4);
+    test_lagrange_coefficients_curve_elements<field_type,
+                            group_type,
+                            geometric_sequence_domain<field_type>,
+                            geometric_sequence_domain<field_type, group_value_type>>(4);
+    test_lagrange_coefficients_curve_elements<field_type,
+                            group_type,
+                            arithmetic_sequence_domain<field_type>,
+                            arithmetic_sequence_domain<field_type, group_value_type>>(4);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
For the purpose of eliminating the toxic waste problem in Groth16 proving system, it is necessary to evaluate all lagrange coefficients as Curve group elements (i.e. multiplied by a group generator) for an evalutation domain without the knowledge of t.
Instead what is available is a vector (t**0 ... t**(m-1)) multlplied by some group generator.
This PR adds said functionality for all evalutation domains.